### PR TITLE
Add build scope to prevent auto rebuild loop

### DIFF
--- a/.externalToolBuilders/Google Protocol Buffers.launch
+++ b/.externalToolBuilders/Google Protocol Buffers.launch
@@ -2,6 +2,7 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType">
 <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_BUILD_SCOPE" value="${working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;resources&gt;&#10;&lt;item path=&quot;/jdiesel/common/protobuf.proto&quot; type=&quot;1&quot;/&gt;&#10;&lt;/resources&gt;}"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${system_path:protoc}"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="--java_out gen common/protobuf.proto"/>


### PR DESCRIPTION
If this option is not set, protoc builder will be triggered if "Build
automatically" is set no matter what resource is updated.  However, the
output for protoc, /gen/com/mwr/jdiesel/Protobuf.java, is a resource for
java builder which will trigger rebuild.  In this case an infinite build
loop happens.  The solution is set the build scope for protoc builder to
common/protobuf.proto only.